### PR TITLE
Escape spaces in SSID, passphrase

### DIFF
--- a/WiFlyHQ.cpp
+++ b/WiFlyHQ.cpp
@@ -2192,18 +2192,27 @@ boolean WiFly::join(uint16_t timeout)
 
 boolean WiFly::join(const char *ssid, const char *password, bool dhcp, uint8_t mode, uint16_t timeout)
 {
-    setSSID(ssid);
-    if (mode == WIFLY_MODE_WPA) {
-	setPassphrase(password);
-    } else {
-	setKey(password);
-    }
+  String temp = ssid;
+  temp.replace(' ', '$');
+  char escapedSSID[strlen(ssid) + 1];
+  temp.toCharArray(escapedSSID, strlen(ssid) + 1);
+  setSSID(escapedSSID);
 
-    if (dhcp) {
-	enableDHCP();
-    }
+  if (mode == WIFLY_MODE_WPA) {
+    temp = password;
+    temp.replace(' ', '$');
+    char escapedPassphrase[strlen(password) + 1];
+    temp.toCharArray(escapedPassphrase, strlen(password) + 1);
+    setPassphrase(escapedPassphrase);
+  } else {
+    setKey(password);
+  }
 
-    return join(ssid, timeout);
+  if (dhcp) {
+    enableDHCP();
+  }
+
+  return join(ssid, timeout);
 }
 
 /** leave the wireless network */
@@ -2809,7 +2818,6 @@ boolean WiFly::close()
 
     return !connected;
 }
-
 
 WFDebug::WFDebug()
 {


### PR DESCRIPTION
The WiFly commands for setting SSID and passphrase (`set wlan ssid
<ssid>` and `set wlan phrase <passphrase>`, respectively) use a dollar
sign ($) in place of the space character, presumably to work around
limitations in its command parser. Most code I've seen that uses the
WiFly RN-XV library works around this limitation simply by inserting
dollar signs into the string that makes up the SSID and passphrase:

const char mySSID[] = "here$be$spaces";
const char myPassword[] = "and$here$be$more";

This works fine for the password, because the only WiFly command that
uses it is `set wlan phrase <passphrase>`. However, the SSID is used
in two places in the various WiFly::join methods, once for setting the
SSID (`set wlan ssid <ssid>`) and once for joining the wireless network
(`join <ssid>`). The `join <ssid>` command does _not_ use dollar signs
as space replacements; in fact, it expects to see space characters, and
using dollar signs results in a failed connection to a network whose
SSID contains spaces.

Long story short, this commit works around the problem by replacing
spaces with dollar signs where appropriate (when calling `set wlan ssid`
and `set wlan phrase`), but passes the SSID intact to the `join`
command. This means that code using the WiFly library can declare SSID
and passphrase strings in a more readable fashion:

const char mySSID[] = "here be spaces";
const char myPassword[] = "and here be more";

One caveat: if the passphrase actually contains dollar signs, this code
will fail to connect, because it will replace them with spaces. However,
the same thing will happen if you directly call the `set wlan phrase`
command in the WiFly command mode; it swaps $ for space already, so this
is known, if somewhat unexpected, behavior. Dollar signs aren't valid
characters in an SSID, so it shouldn't be a problem there.
