### PR TITLE
Added time() and sleep() functions

### DIFF
--- a/WiFlyHQ.cpp
+++ b/WiFlyHQ.cpp
@@ -1446,6 +1446,26 @@ uint32_t WiFly::getBaud()
 }
 
 /**
+ * This command puts the module to sleep. You can wake
+ * the module by sending characters over the UART or by
+ * using the wake timer (supplied in seconds).
+ */
+boolean WiFly::sleep(uint16_t seconds)
+{
+    if (seconds != NULL) {
+        if(!setopt(PSTR("set sys wake"), seconds)) {
+            return false;
+        }
+    }
+    if (!startCommand()) {
+        return false;
+    }
+    send_P(PSTR("sleep\r"));
+    inCommandMode = false;
+    return true;
+}
+
+/**
  * This command sets the real-time clock by synchronizing
  * with the time server specified with the time server
  * (set time) parameters. This command sends a UDP time

--- a/WiFlyHQ.h
+++ b/WiFlyHQ.h
@@ -221,6 +221,8 @@ public:
 
     boolean setIOFunc(const uint8_t func);
     
+    boolean sleep(uint16_t seconds = NULL);
+    
     boolean time();
     char *getTime(char *buf, int size);
     uint32_t getUptime();


### PR DESCRIPTION
From the documentation: "This command sets the real-time clock by
synchronizing with the time server specified with the time server (set
time) parameters. This command sends a UDP time server request packet."

Also added sleep() function per mgrey's recommendations: https://github.com/harlequin-tech/WiFlyHQ/issues/9
