### PR TITLE
Ping update

### DIFF
--- a/WiFlyHQ.cpp
+++ b/WiFlyHQ.cpp
@@ -2481,7 +2481,6 @@ boolean WiFly::ping(const char *host)
     send('\r');
 
     match_P(PSTR("Ping try"));
-    gets(NULL,0);
     if (!getPrompt()) {
         finishCommand();
         return false;
@@ -2490,10 +2489,12 @@ boolean WiFly::ping(const char *host)
     if (match_P(PSTR("reply from"), 5000)) {
         flushRx(); //as long as we get a "reply from" it's good.
         finishCommand();
+        DPRINTLN(F("ping success"));
         return true;
     }
 
     finishCommand();
+    DPRINTLN(F("ping fail"));
     return false;
 }
 

--- a/WiFlyHQ.cpp
+++ b/WiFlyHQ.cpp
@@ -2487,9 +2487,8 @@ boolean WiFly::ping(const char *host)
         return false;
     }
 
-    if (match_P(PSTR("64 bytes"), 5000)) {
-        gets(NULL,0);
-        gets(NULL,0, 5000);
+    if (match_P(PSTR("reply from"), 5000)) {
+        flushRx(); //as long as we get a "reply from" it's good.
         finishCommand();
         return true;
     }


### PR DESCRIPTION
recent firmware no longer says "64 bytes" and so all pings fail. I believe all versions say "reply from" so this should be backwards compatible.